### PR TITLE
Added method climetlab.sources.readers.grib.valid_datetime

### DIFF
--- a/climetlab/sources/readers/grib.py
+++ b/climetlab/sources/readers/grib.py
@@ -124,6 +124,10 @@ class GribField:
             date // 10000, date % 10000 // 100, date % 100, time // 100, time % 100
         )
 
+    def valid_datetime(self):
+        step = self.handle.get("endStep")
+        return self.datetime() + datetime.timedelta(hours=step)
+
 
 class GRIBIterator:
     def __init__(self, path):

--- a/climetlab/sources/readers/grib.py
+++ b/climetlab/sources/readers/grib.py
@@ -72,6 +72,14 @@ class GribField:
     def values(self):
         return self.handle.get("values")
 
+    @property
+    def offset(self):
+        return int(self.handle.get("offset"))
+
+    @property
+    def shape(self):
+        return self.handle.get("Nj"), self.handle.get("Ni")
+
     def plot_map(self, driver):
         driver.bounding_box(
             north=self.handle.get("latitudeOfFirstGridPointInDegrees"),
@@ -82,11 +90,7 @@ class GribField:
         driver.plot_grib(self.path, self.handle.get("offset"))
 
     def to_numpy(self):
-        return self.values.reshape((self.handle.get("Nj"), self.handle.get("Ni")))
-
-    @property
-    def offset(self):
-        return int(self.handle.get("offset"))
+        return self.values.reshape(self.shape)
 
     def __repr__(self):
         return "GribField(%s,%s,%s,%s,%s,%s)" % (

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -16,6 +16,9 @@ def test_grib():
     for s in load_source("file", "docs/examples/test.grib"):
         plot_map(s)
 
+        # test.grib fields endStep is 0, so datetime == valid_datetime
+        assert s.datetime() == s.valid_datetime()
+
 
 if __name__ == "__main__":
     test_grib()

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -8,3 +8,14 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 #
+
+from climetlab import load_source, plot_map
+
+
+def test_grib():
+    for s in load_source("file", "docs/examples/test.grib"):
+        plot_map(s)
+
+
+if __name__ == "__main__":
+    test_grib()

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -19,6 +19,9 @@ def test_grib():
         # test.grib fields endStep is 0, so datetime == valid_datetime
         assert s.datetime() == s.valid_datetime()
 
+        # test shape
+        assert s.shape == (11, 19)
+
 
 if __name__ == "__main__":
     test_grib()


### PR DESCRIPTION
Added method to the _GribField.valid_datetime_ which adds the value of GRIB "endStep" to the already exiusting method _GribField.valid_datetime_.

Note: I (really) cannot access a method _step_ from this class.