### PR TITLE
Using 'with' on a GribField as returned from load_source

### DIFF
--- a/climetlab/sources/readers/grib.py
+++ b/climetlab/sources/readers/grib.py
@@ -72,8 +72,8 @@ class GribField:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_tb is not None:
-            raise exc_type(exc_val)  # raise on non-empty traceback
+        # Place to suppress exceptions (don't reraise the passed-in exception, it is the caller's responsibility)
+        pass
 
     @property
     def values(self):

--- a/climetlab/sources/readers/grib.py
+++ b/climetlab/sources/readers/grib.py
@@ -68,6 +68,13 @@ class GribField:
         self.handle = handle
         self.path = path
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_tb is not None:
+            raise exc_type(exc_val)  # raise on non-empty traceback
+
     @property
     def values(self):
         return self.handle.get("values")


### PR DESCRIPTION
Support for using 'with' on a GribField as returned from load_source.

These methods `__enter__` and `__exit__` are for exception handling and pre-initialize members which aren't really necessary for GRIBs (but the methods must be present).

Possibly should be used with netCDF and maybe other formats too (but, I'm currently not working with netCDF and it is probably the wrong example anyway so I didn't add it).