### PR TITLE
Dataset "hurricate-database" on Python<3.7

### DIFF
--- a/climetlab/utils/datetime.py
+++ b/climetlab/utils/datetime.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 # datetime.fromisoformat() only available from Python3.7
 # from backports.datetime_fromisoformat import MonkeyPatch
 from dateutil.parser import parse
+from re import sub
 
 # MonkeyPatch.patch_fromisoformat()
 
@@ -21,6 +22,7 @@ def parse_date(date):
     try:
         return datetime.datetime.fromisoformat(date)
     except Exception:
+        date = sub(r"Z.*", "", date)
         return parse(date)
 
 

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -25,4 +25,3 @@ def test_grib():
 
 if __name__ == "__main__":
     test_grib()
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ def test_bytes():
     assert bytes_to_string(1024) == "1 KiB"
     assert bytes_to_string(1024 * 1024) == "1 MiB"
 
+
 def test_bbox():
 
     for i in range(-365, 365):
@@ -61,6 +62,6 @@ def test_bbox():
         bbox = bbox2.merge(bbox1)
         assert bbox.width == 60, (bbox1, bbox2, bbox)
 
+
 def test_parse_date():
     dt.parse_date("1851-06-25Z00:00")
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,14 +10,13 @@
 #
 
 from climetlab.core.bbox import BoundingBox
-from climetlab.utils import bytes_to_string
+from climetlab.utils import bytes_to_string, datetime as dt
 
 
 def test_bytes():
     assert bytes_to_string(10) == "10"
     assert bytes_to_string(1024) == "1 KiB"
     assert bytes_to_string(1024 * 1024) == "1 MiB"
-
 
 def test_bbox():
 
@@ -61,3 +60,7 @@ def test_bbox():
 
         bbox = bbox2.merge(bbox1)
         assert bbox.width == 60, (bbox1, bbox2, bbox)
+
+def test_parse_date():
+    dt.parse_date("1851-06-25Z00:00")
+


### PR DESCRIPTION
The dataset "hurricate-database" uses 'datetime.fromisoformat' on Python>=3.7, but the alternate way to parse dates fails on dates from this datase, like "1851-06-25Z00:00".

This fix just discards from "Z.*" onwards' before passing on to the parser.