### PR TITLE
Fix in grib output from metadata.

### DIFF
--- a/climetlab/readers/grib/output.py
+++ b/climetlab/readers/grib/output.py
@@ -121,7 +121,7 @@ class GribOutput:
 
         if "time" not in metadata and "date" in metadata:
             date = metadata["date"]
-            metadata["date"] = date.hour * 100 + date.minute
+            metadata["time"] = date.hour * 100 + date.minute
 
         if "date" in metadata:
             date = metadata["date"]


### PR DESCRIPTION
When time was not present in metadata it was overwriting date instead of providing a time.