### PR TITLE
fix indexed_urls::get_index_url substitute extension logic

### DIFF
--- a/climetlab/sources/indexed_urls.py
+++ b/climetlab/sources/indexed_urls.py
@@ -18,7 +18,7 @@ from climetlab.utils.patterns import Pattern
 
 def get_index_url(url, substitute_extension, index_extension):
     if substitute_extension:
-        url = ".".join(".".split(url)[:-1])
+        url = ".".join(url.split(".")[:-1])
 
     if callable(index_extension):
         return index_extension(url)


### PR DESCRIPTION
Split url on `"."`, instead of the other way round.